### PR TITLE
feat: Add `encoding` option for binary output (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,36 @@ import spawnAsync from '@expo/spawn-async';
 `spawnAsync` takes the same arguments as [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options). Its options are the same as those of `child_process.spawn` plus:
 
 - `ignoreStdio`: whether to ignore waiting for the child process's stdio streams to close before resolving the result promise. When ignoring stdio, the returned values for `stdout` and `stderr` will be empty strings. The default value of this option is `false`.
-- `maxBuffer`: the maximum bytes retained from `stdout` and `stderr` (independently). Output is collected with a sliding window. When set explicitly, exceeding it rejects the promise with an error whose `code` is `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` and whose `stdout`/`stderr` carry the truncated tail. When omitted, the default is `buffer.constants.MAX_STRING_LENGTH` (~512 MiB).
+- `maxBuffer`: the maximum bytes retained from `stdout` and `stderr` (independently). Output is collected with a sliding window. Exceeding the cap rejects the promise with `code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'`; the most recent bytes that fit are attached to the error's stdio fields. The default is `buffer.constants.MAX_STRING_LENGTH`. Under `encoding: 'buffer'` the caller may pass a larger value, up to `buffer.constants.MAX_LENGTH`. Passing a value larger than the encoding's hard limit throws `TypeError` synchronously.
+- `encoding`: selects whether the child's output is exposed as decoded strings or raw bytes. The default `'utf8'` (and any other [`BufferEncoding`](https://nodejs.org/api/buffer.html#buffers-and-character-encodings) value such as `'latin1'` or `'hex'`) decodes the child's output into a string. The value `'buffer'` keeps the output as raw `Uint8Array` instead. The `stdout` / `stderr` / `output` field names are the same in either mode; only their type changes.
 
 It returns a promise whose result is an object with these properties:
 
 - `pid`: the process ID of the spawned child process
-- `output`: an array with stdout and stderr's output
-- `stdout`: a string of what the child process wrote to stdout
-- `stderr`: a string of what the child process wrote to stderr
+- `stdout`: what the child process wrote to stdout — a `string` for text encodings, or a `Uint8Array` under `encoding: 'buffer'`
+- `stderr`: same shape as `stdout`, but for stderr
+- `output`: `[stdout, stderr]`
 - `status`: the exit code of the child process
 - `signal`: the signal (ex: `SIGTERM`) used to stop the child process if it did not exit on its own
 
+The `Uint8Array` returned by `'buffer'` mode is a Node `Buffer` at runtime, so callers who need `Buffer`-specific methods can do `Buffer.from(result.stdout)` for a zero-copy view of the same memory.
+
 If there's an error running the child process or it exits with a non-zero status code, `spawnAsync` rejects the returned promise. The Error object also has the properties listed above.
+
+### Reading binary output
+
+```js
+import fs from 'node:fs';
+import spawnAsync from '@expo/spawn-async';
+
+const result = await spawnAsync(
+  'pandoc',
+  ['--from=html', '--to=docx'],
+  { encoding: 'buffer' }
+);
+result.child.stdin.end('<h1>Hello, world</h1>');
+fs.writeFileSync('out.docx', result.stdout);  // Uint8Array
+```
 
 ### Accessing the child process
 
@@ -70,8 +88,14 @@ Here is an example:
 
 ### `maxBuffer`
 
-`maxBuffer` is a later addition to the API. Set it when child output could exhaust memory and crash the parent process, or when the command or arguments are influenced by untrusted input — an attacker can otherwise force unbounded output to crash the parent.
+Set `maxBuffer` when child output could exhaust memory and crash the parent process, or when the command or arguments are influenced by untrusted input; an attacker can otherwise force unbounded output to crash the parent.
 
-The default of `buffer.constants.MAX_STRING_LENGTH` (~512 MiB) is a crash-safe floor, not a memory bound: at that size the materialized string itself can still exhaust process memory.
+The default `maxBuffer` is `buffer.constants.MAX_STRING_LENGTH`. For text encodings that is also the runtime hard limit (the longest string `Buffer.toString()` can build without crashing). Under `encoding: 'buffer'` the runtime allows up to `buffer.constants.MAX_LENGTH`, but the default stays at `MAX_STRING_LENGTH` for consistency; callers that need more output pass a larger `maxBuffer` explicitly. At either size the materialized output can still exhaust process memory.
 
-When `maxBuffer` is set explicitly, exceeding it rejects the promise immediately with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`. When left at the default, exceeding it doesn't reject; the sliding-window tail is still readable, but reading `stdout`/`stderr` throws `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` with the truncated tail attached.
+Exceeding the cap rejects the promise with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, regardless of whether the cap was explicit or the default. The most recent bytes that fit are attached to `error.stdout` and `error.stderr`.
+
+Passing `maxBuffer` larger than the encoding's hard limit throws `TypeError` synchronously at the call site.
+
+### Memory profile
+
+During the child's lifetime the per-chunk buffers Node delivers are retained as they arrive. When the process exits the chunks are concatenated once and decoded if a text encoding was requested; at that moment peak memory is briefly ~2× the output size (the chunk array plus the concatenated result). The chunk references are dropped immediately afterward, so steady-state memory is ~1× the output: either the decoded string (text encodings) or the `Uint8Array` (`encoding: 'buffer'`).

--- a/src/__tests__/spawnAsync-test.ts
+++ b/src/__tests__/spawnAsync-test.ts
@@ -1,7 +1,13 @@
 import assert from 'assert';
+import { constants as bufferConstants } from 'buffer';
 import path from 'path';
 
 import spawnAsync, { SpawnOptions, SpawnPromise, SpawnResult } from '../spawnAsync';
+
+// Captured at file load, before any `jest.doMock('buffer', …)` in later tests
+// can swap the constants out from under us.
+const REAL_MAX_STRING_LENGTH = bufferConstants.MAX_STRING_LENGTH;
+const REAL_MAX_LENGTH = bufferConstants.MAX_LENGTH;
 
 it(`receives output from completed processes`, async () => {
   let result = await spawnAsync('echo', ['hi']);
@@ -238,50 +244,72 @@ it(`listens on 'close' (not 'exit') when stdio is piped`, async () => {
   await task;
 });
 
-describe(`default-cap (lazy) maxBuffer path`, () => {
-  // The lazy path only triggers against MAX_STRING_LENGTH (~512 MiB), which is
-  // impractical to generate. Mock the constant so the same code path activates
-  // at a testable size.
-  function spawnAsyncWithCap(cap: number) {
+describe(`default-cap maxBuffer path`, () => {
+  // The default text cap is MAX_STRING_LENGTH (~512 MiB), which is impractical
+  // to generate. Mock the constant so the same code path activates at a
+  // testable size.
+  function spawnAsyncWithCap(
+    cap: number,
+    encoding?: spawnAsync.SpawnOptions['encoding']
+  ) {
     let task: any;
     jest.isolateModules(() => {
       jest.doMock('buffer', () => {
         const actual = jest.requireActual<typeof import('buffer')>('buffer');
         return {
           ...actual,
-          constants: { ...actual.constants, MAX_STRING_LENGTH: cap },
+          constants: {
+            ...actual.constants,
+            MAX_STRING_LENGTH: cap,
+            MAX_LENGTH: cap,
+          },
         };
       });
       const localSpawnAsync = require('../spawnAsync');
       task = localSpawnAsync(
         process.execPath,
-        ['-e', 'process.stdout.write("a".repeat(100), () => process.stdout.write("b".repeat(50)));']
+        ['-e', 'process.stdout.write("a".repeat(100), () => process.stdout.write("b".repeat(50)));'],
+        encoding ? { encoding } : undefined
       );
     });
-    return task as Promise<SpawnResult> & { child: any };
+    return task;
   }
 
-  it(`resolves the promise without rejecting`, async () => {
-    const result = await spawnAsyncWithCap(100);
-    expect(result.status).toBe(0);
-    expect(result.signal).toBe(null);
+  it(`rejects suggesting the string-length limit when text output exceeds it`, async () => {
+    let caught: any;
+    try {
+      await spawnAsyncWithCap(100);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('ERR_CHILD_PROCESS_STDIO_MAXBUFFER');
+    expect(caught.message).toMatch(/the maximum string length \(100 bytes, buffer\.constants\.MAX_STRING_LENGTH\)/);
+    // Suggests the only real remedy: switching to bytes.
+    expect(caught.message).toMatch(/encoding: "buffer"/);
+    // The sliding-window tail is still attached so callers can inspect it.
+    expect(caught.stdout).toBe('a'.repeat(50) + 'b'.repeat(50));
+    expect(caught.stderr).toBe('');
+    expect(caught.status).toBe(0);
   });
 
-  it(`throws ERR_CHILD_PROCESS_STDIO_MAXBUFFER on stdout access with the truncated tail`, async () => {
-    const result = await spawnAsyncWithCap(100);
-    let error: any;
-    try { void result.stdout; } catch (e) { error = e; }
-    expect(error).toMatchObject({
-      code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
-      stdout: 'a'.repeat(50) + 'b'.repeat(50),
-      stderr: '',
-    });
-  });
-
-  it(`only throws on the overflowed stream; the other reads normally`, async () => {
-    const result = await spawnAsyncWithCap(100);
-    expect(result.stderr).toBe('');
-    expect(() => result.stdout).toThrow();
+  it(`rejects suggesting a larger maxBuffer when bytes output exceeds the default cap`, async () => {
+    let caught: any;
+    try {
+      await spawnAsyncWithCap(100, 'buffer');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('ERR_CHILD_PROCESS_STDIO_MAXBUFFER');
+    expect(caught.message).toMatch(/exceeded the default maxBuffer of 100 bytes/);
+    // The default cap in buffer mode is not the runtime ceiling, so the
+    // message points the caller at a larger maxBuffer.
+    expect(caught.message).toMatch(/Pass maxBuffer to capture more output/);
+    expect(caught.message).toMatch(/buffer\.constants\.MAX_LENGTH/);
+    expect(Buffer.from(caught.stdout).toString()).toBe(
+      'a'.repeat(50) + 'b'.repeat(50)
+    );
   });
 });
 
@@ -290,4 +318,142 @@ it(`exports TypeScript types`, async () => {
   let promise: SpawnPromise<SpawnResult> = spawnAsync('echo', ['hi'], options);
   let result: SpawnResult = await promise;
   expect(typeof result.pid).toBe('number');
+});
+
+describe(`encoding: 'buffer'`, () => {
+  it(`returns stdout/stderr as Uint8Array`, async () => {
+    const expected = Buffer.from([0, 1, 2, 0xff, 0x80, 0x7f]);
+    const result = await spawnAsync(
+      process.execPath,
+      [
+        '-e',
+        `process.stdout.write(Buffer.from(${JSON.stringify(Array.from(expected))}));`,
+      ],
+      { encoding: 'buffer' }
+    );
+    expect(result.stdout).toBeInstanceOf(Uint8Array);
+    expect(result.stdout.byteLength).toBe(expected.byteLength);
+    expect(Buffer.from(result.stdout).equals(expected)).toBe(true);
+    expect(result.stderr.byteLength).toBe(0);
+  });
+
+  it(`survives a byte sequence that is not valid UTF-8`, async () => {
+    // The continuation byte 0xC0 followed by 0x00 would be replaced by U+FFFD
+    // when decoded as UTF-8, losing information. With encoding: 'buffer' we get
+    // the exact bytes back.
+    const bytes = Buffer.from([0xc0, 0x00, 0xc1, 0xff]);
+    const result = await spawnAsync(
+      process.execPath,
+      [
+        '-e',
+        `process.stdout.write(Buffer.from(${JSON.stringify(Array.from(bytes))}));`,
+      ],
+      { encoding: 'buffer' }
+    );
+    expect(Buffer.from(result.stdout).equals(bytes)).toBe(true);
+  });
+
+  it(`populates output as [stdout, stderr] of Uint8Array`, async () => {
+    const result = await spawnAsync(
+      process.execPath,
+      ['-e', 'process.stdout.write("ok"); process.stderr.write("warn");'],
+      { encoding: 'buffer' }
+    );
+    expect(result.output).toHaveLength(2);
+    expect(result.output[0]).toBe(result.stdout);
+    expect(result.output[1]).toBe(result.stderr);
+    expect(result.output[0]).toBeInstanceOf(Uint8Array);
+  });
+
+  it(`attaches bytes to the error on non-zero exit, like string stdout`, async () => {
+    const expected = Buffer.from([0x10, 0x20, 0x30]);
+    let caught: any;
+    try {
+      await spawnAsync(
+        process.execPath,
+        [
+          '-e',
+          `process.stdout.write(Buffer.from(${JSON.stringify(Array.from(expected))})); process.exit(7);`,
+        ],
+        { encoding: 'buffer' }
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.status).toBe(7);
+    expect(Buffer.from(caught.stdout).equals(expected)).toBe(true);
+  });
+
+  it(`enforces maxBuffer with encoding: 'buffer'`, async () => {
+    await expect(
+      spawnAsync(
+        process.execPath,
+        ['-e', 'process.stdout.write(Buffer.alloc(1000, 0xab));'],
+        { encoding: 'buffer', maxBuffer: 100 }
+      )
+    ).rejects.toMatchObject({
+      code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
+    });
+  });
+});
+
+describe(`encoding: text encodings other than utf8`, () => {
+  it(`decodes stdout with the requested encoding`, async () => {
+    // Latin-1 maps 0x00–0xff one-to-one to U+0000–U+00FF. Bytes that would be
+    // multibyte continuations in UTF-8 (e.g. 0xC0, 0xFF) decode cleanly here.
+    const bytes = Buffer.from([0xc0, 0xc1, 0xff]);
+    const result = await spawnAsync(
+      process.execPath,
+      [
+        '-e',
+        `process.stdout.write(Buffer.from(${JSON.stringify(Array.from(bytes))}));`,
+      ],
+      { encoding: 'latin1' }
+    );
+    expect(result.stdout).toBe(bytes.toString('latin1'));
+    expect(result.stdout).toBe('ÀÁÿ');
+  });
+
+  it(`decodes stdout with hex encoding`, async () => {
+    const result = await spawnAsync(
+      process.execPath,
+      ['-e', 'process.stdout.write(Buffer.from([0xde, 0xad, 0xbe, 0xef]));'],
+      { encoding: 'hex' }
+    );
+    expect(result.stdout).toBe('deadbeef');
+  });
+});
+
+describe(`maxBuffer validation`, () => {
+  it(`throws TypeError synchronously when maxBuffer exceeds MAX_STRING_LENGTH in text mode`, () => {
+    expect(() =>
+      spawnAsync('echo', ['hi'], { maxBuffer: REAL_MAX_STRING_LENGTH + 1 })
+    ).toThrow(TypeError);
+    expect(() =>
+      spawnAsync('echo', ['hi'], { maxBuffer: REAL_MAX_STRING_LENGTH + 1 })
+    ).toThrow(/exceeds the maximum string length/);
+  });
+
+  it(`throws TypeError synchronously when maxBuffer exceeds MAX_LENGTH in buffer mode`, () => {
+    if (REAL_MAX_LENGTH >= Number.MAX_SAFE_INTEGER) {
+      // On runtimes where MAX_LENGTH already equals MAX_SAFE_INTEGER there's
+      // no representable integer Number larger than it, so this case is
+      // unreachable. Recent Node sets MAX_LENGTH this high.
+      return;
+    }
+    expect(() =>
+      spawnAsync('echo', ['hi'], {
+        encoding: 'buffer',
+        maxBuffer: REAL_MAX_LENGTH + 1,
+      })
+    ).toThrow(/exceeds the maximum byte array length/);
+  });
+
+  it(`accepts maxBuffer exactly equal to MAX_STRING_LENGTH`, async () => {
+    const result = await spawnAsync('echo', ['hi'], {
+      maxBuffer: REAL_MAX_STRING_LENGTH,
+    });
+    expect(result.stdout).toBe('hi\n');
+  });
 });

--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -6,17 +6,31 @@ namespace spawnAsync {
   export interface SpawnOptions extends NodeSpawnOptions {
     ignoreStdio?: boolean;
     maxBuffer?: number;
+    /**
+     * Selects the type of `stdout` / `stderr` on the resolved result.
+     *
+     * - A `BufferEncoding` (the default "utf8", or "latin1", "hex", etc.)
+     *   decodes the child's output to a string.
+     * - "buffer" keeps the output as raw bytes (`Uint8Array`).
+     *
+     * Bytes are typed as `Uint8Array`; the runtime value is a Node `Buffer`,
+     * which extends `Uint8Array`, so no conversion is performed.
+     */
+    encoding?: BufferEncoding | 'buffer';
   }
 
   export interface SpawnPromise<T> extends Promise<T> {
     child: ChildProcess;
   }
 
-  export interface SpawnResult {
+  // Parameterized on the stdio element type. Defaults to `string`, so existing
+  // `SpawnResult` references resolve to the text shape with no source changes.
+  // `encoding: "buffer"` returns `SpawnResult<Uint8Array>`.
+  export interface SpawnResult<T = string> {
     pid?: number;
-    output: string[];
-    stdout: string;
-    stderr: string;
+    output: T[];
+    stdout: T;
+    stderr: T;
     status: number | null;
     signal: string | null;
   }
@@ -29,177 +43,199 @@ interface IOChunksState {
   maxExceeded: boolean;
 }
 
-const DEFAULT_MAX_BUFFER = bufferConstants.MAX_STRING_LENGTH;
-
+// `encoding: "buffer"` (the literal) returns the bytes shape; everything else
+// (no options, a text encoding, or a `SpawnOptions`-typed variable that doesn't
+// statically pin "buffer") returns the string shape. This is the same overload
+// pattern Node uses for `child_process.spawnSync`.
+function spawnAsync(
+  command: string,
+  args: ReadonlyArray<string> | undefined,
+  options: spawnAsync.SpawnOptions & { encoding: 'buffer' }
+): spawnAsync.SpawnPromise<spawnAsync.SpawnResult<Uint8Array>>;
+function spawnAsync(
+  command: string,
+  args?: ReadonlyArray<string>,
+  options?: spawnAsync.SpawnOptions
+): spawnAsync.SpawnPromise<spawnAsync.SpawnResult>;
 function spawnAsync(
   command: string,
   args?: ReadonlyArray<string>,
   options: spawnAsync.SpawnOptions = {}
-): spawnAsync.SpawnPromise<spawnAsync.SpawnResult> {
+): spawnAsync.SpawnPromise<spawnAsync.SpawnResult<string | Uint8Array>> {
   const stubError = new Error();
   const callerStack = stubError.stack ? stubError.stack.replace(/^.*/, '    ...') : null;
 
   const {
     ignoreStdio: optionsIgnoreStdio,
     maxBuffer: optionsMaxBuffer,
+    encoding: optionsEncoding,
     ...nodeOptions
   } = options;
 
-  // NOTE(@kitten): When `maxBuffer` is set explicitly, we enforce it strictly
-  // and don't produce a result without it being strictly enforced
-  const enforceMaxBufferStrictly = optionsMaxBuffer != null;
+  const encoding: BufferEncoding | 'buffer' = optionsEncoding ?? 'utf8';
+  const wantsBytes = encoding === 'buffer';
 
+  const explicitMaxBuffer = optionsMaxBuffer != null;
   const ignoreStdio = !!optionsIgnoreStdio;
-  const maxBuffer = Math.min(
-    optionsMaxBuffer ?? DEFAULT_MAX_BUFFER,
-    bufferConstants.MAX_STRING_LENGTH,
-  );
+  // The runtime hard limit (the largest value `maxBuffer` may take). Text
+  // encodings go through `Buffer.toString()`, which cannot produce a string
+  // longer than `MAX_STRING_LENGTH` without crashing the runtime. The "buffer"
+  // encoding skips the string conversion, so its only ceiling is the maximum
+  // size of a single `Buffer` (`MAX_LENGTH`).
+  const hardLimit = wantsBytes
+    ? bufferConstants.MAX_LENGTH
+    : bufferConstants.MAX_STRING_LENGTH;
+  // Validate the caller's maxBuffer against the runtime hard limit. Silently
+  // clamping was the previous behavior and led to confusing rejection messages
+  // later. Surface the misconfiguration synchronously so it's obvious at the
+  // call site.
+  if (optionsMaxBuffer != null && optionsMaxBuffer > hardLimit) {
+    const limitName = wantsBytes
+      ? 'buffer.constants.MAX_LENGTH'
+      : 'buffer.constants.MAX_STRING_LENGTH';
+    const remedy = wantsBytes
+      ? ''
+      : ' Pass encoding: "buffer" to raise the ceiling to buffer.constants.MAX_LENGTH.';
+    throw new TypeError(
+      `maxBuffer (${optionsMaxBuffer}) exceeds the maximum ` +
+        `${wantsBytes ? 'byte array' : 'string'} length ` +
+        `(${hardLimit}, ${limitName}).${remedy}`,
+    );
+  }
+  // Default cap is `MAX_STRING_LENGTH` regardless of encoding. Under
+  // `encoding: "buffer"`, the runtime allows up to `MAX_LENGTH`, so a caller
+  // that wants more output explicitly passes a larger `maxBuffer` (the
+  // TypeError above bounds it to `MAX_LENGTH`).
+  const maxBuffer = optionsMaxBuffer ?? bufferConstants.MAX_STRING_LENGTH;
 
   let child: ChildProcess = spawn(command, args, nodeOptions);
-  let promise = new Promise((resolve, reject) => {
-    const stdoutChunks: IOChunksState = { buffer: [], maxExceeded: false };
-    const stderrChunks: IOChunksState = { buffer: [], maxExceeded: false };
+  let promise = new Promise<spawnAsync.SpawnResult<string | Uint8Array>>(
+    (resolve, reject) => {
+      const stdoutChunks: IOChunksState = { buffer: [], maxExceeded: false };
+      const stderrChunks: IOChunksState = { buffer: [], maxExceeded: false };
 
-    function makeHandler(chunks: IOChunksState) {
-      let length = 0;
-      return (chunk: IOChunk) => {
-        chunks.buffer.push(chunk);
-        length += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
-        while (chunks.buffer.length > 0 && length > maxBuffer) {
-          chunks.maxExceeded = true;
-          chunk = chunks.buffer[0];
-          const chunkLength = typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
-          if (length - chunkLength < maxBuffer) {
-            const replacement = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
-            const excess = length - maxBuffer;
-            chunks.buffer[0] = replacement.subarray(excess);
-            length -= excess;
-            break;
-          } else {
-            chunks.buffer.shift();
-            length -= chunkLength;
+      // Build the `'data'` listener for one stream: it appends each chunk and
+      // keeps the retained total within `maxBuffer` by dropping the oldest bytes
+      // (a sliding window). Each stream gets its own listener with its own
+      // running `length`.
+      function makeChunkCollector(chunks: IOChunksState) {
+        let length = 0;
+        return function collectChunk(chunk: IOChunk) {
+          chunks.buffer.push(chunk);
+          length += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
+          while (chunks.buffer.length > 0 && length > maxBuffer) {
+            chunks.maxExceeded = true;
+            chunk = chunks.buffer[0];
+            const chunkLength = typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.byteLength;
+            if (length - chunkLength < maxBuffer) {
+              const replacement = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+              const excess = length - maxBuffer;
+              chunks.buffer[0] = replacement.subarray(excess);
+              length -= excess;
+              break;
+            } else {
+              chunks.buffer.shift();
+              length -= chunkLength;
+            }
           }
-        }
-      };
-    }
-
-    function attachResult<T extends spawnAsync.SpawnResult | (Error & Partial<spawnAsync.SpawnResult>)>(
-      target: T,
-      assign: Partial<spawnAsync.SpawnResult>,
-      stdoutChunks: IOChunksState,
-      stderrChunks: IOChunksState,
-      skipMaxBufferCheck?: boolean,
-    ): T {
-      function makeMaxBufferError() {
-        const argumentString = args && args.length > 0 ? ` ${args.join(' ')}` : '';
-        const error: Error & { code?: string } = new Error(`${command}${argumentString} exceeded maxBuffer of ${maxBuffer} bytes`);
-        error.code = 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
-        return attachResult(error, assign, stdoutChunks, stderrChunks, true);
-      }
-
-      let _stdout: string | undefined;
-      let _stderr: string | undefined;
-      const map: PropertyDescriptorMap = {
-        stdout: {
-          enumerable: true,
-          configurable: true,
-          get() {
-            if (!skipMaxBufferCheck && stdoutChunks.maxExceeded) {
-              throw makeMaxBufferError();
-            } else if (_stdout === undefined) {
-              _stdout = Buffer.concat(
-                stdoutChunks.buffer.map((chunk) => typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
-              ).toString('utf8');
-            }
-            return _stdout;
-          },
-        },
-        stderr: {
-          enumerable: true,
-          configurable: true,
-          get() {
-            if (!skipMaxBufferCheck && stderrChunks.maxExceeded) {
-              throw makeMaxBufferError();
-            } else if (_stderr === undefined) {
-              _stderr = Buffer.concat(
-                stderrChunks.buffer.map((chunk) => typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
-              ).toString('utf8');
-            }
-            return _stderr;
-          },
-        },
-        output: {
-          enumerable: true,
-          configurable: true,
-          get: () => [target.stdout, target.stderr],
-        },
-      };
-      for (const key in assign) {
-        map[key] = {
-          value: assign[key as keyof spawnAsync.SpawnResult],
-          enumerable: true,
-          writable: true,
-          configurable: true,
         };
       }
-      Object.defineProperties(target, map);
-      return target;
-    }
 
-    if (!ignoreStdio) {
-      child.stdout?.on('data', makeHandler(stdoutChunks));
-      child.stderr?.on('data', makeHandler(stderrChunks));
-    }
-
-    // Use 'exit' instead of 'close' when there are no piped stdio streams for us to drain;
-    // 'close' can be deferred past 'exit' when the child has grandchildren that inherit its
-    // stdio fds, so waiting on it without anything to read just stalls
-    const completionEvent =
-      ignoreStdio || (!child.stdout && !child.stderr) ? 'exit' : 'close';
-
-    let completionListener = (code: number | null, signal: string | null) => {
-      child.removeListener('error', errorListener);
-      const argumentString = args && args.length > 0 ? ` ${args.join(' ')}` : '';
-      let error: (Error & { code?: string }) | null = null;
-      if (code !== 0) {
-        error = signal
-          ? new Error(`${command}${argumentString} exited with signal: ${signal}`)
-          : new Error(`${command}${argumentString} exited with non-zero code: ${code}`);
+      // Concatenate a stream's chunks into one contiguous buffer and drop the
+      // per-chunk references so they can be freed.
+      function concatChunks(chunks: IOChunksState): Buffer {
+        const concatenated = Buffer.concat(
+          chunks.buffer.map((chunk) => (typeof chunk === 'string' ? Buffer.from(chunk) : chunk))
+        );
+        chunks.buffer = [];
+        return concatenated;
       }
-      const assignResult: Partial<spawnAsync.SpawnResult> = {
-        pid: child.pid,
-        status: code,
-        signal,
-      };
-      if (error) {
-        if (error.stack && callerStack) error.stack += `\n${callerStack}`;
-        // When we're already rejecting, we don't enforce the max buffer error, and accept that we
-        // may truncate stderr/stdout
-        reject(attachResult(error, assignResult, stdoutChunks, stderrChunks, true));
-      } else if (enforceMaxBufferStrictly && (stdoutChunks.maxExceeded || stderrChunks.maxExceeded)) {
-        // When a `maxBuffer` is passed, we enforce the maximum on stdout and stderr strictly
-        const error: Error & { code?: string } = new Error(`${command}${argumentString} exceeded maxBuffer of ${maxBuffer} bytes`);
-        error.code = 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
-        reject(attachResult(error, assignResult, stdoutChunks, stderrChunks, true));
-      } else {
-        const result = {} as spawnAsync.SpawnResult;
-        resolve(attachResult(result, assignResult, stdoutChunks, stderrChunks));
+
+      // Build the encoding-appropriate stdio fields as a plain object. Called
+      // exactly once per spawn, so concatenating (and freeing the chunks) here
+      // is the single materialization point.
+      function stdioFields(): Pick<
+        spawnAsync.SpawnResult<string | Uint8Array>,
+        'stdout' | 'stderr' | 'output'
+      > {
+        if (wantsBytes) {
+          const stdout = concatChunks(stdoutChunks);
+          const stderr = concatChunks(stderrChunks);
+          return { stdout, stderr, output: [stdout, stderr] };
+        }
+        const stdout = concatChunks(stdoutChunks).toString(encoding as BufferEncoding);
+        const stderr = concatChunks(stderrChunks).toString(encoding as BufferEncoding);
+        return { stdout, stderr, output: [stdout, stderr] };
       }
-    };
 
-    let errorListener = (error: Error) => {
-      child.removeListener(completionEvent, completionListener);
-      const assignResult: Partial<spawnAsync.SpawnResult> = {
-        pid: child.pid,
-        status: null,
-        signal: null,
+      if (!ignoreStdio) {
+        child.stdout?.on('data', makeChunkCollector(stdoutChunks));
+        child.stderr?.on('data', makeChunkCollector(stderrChunks));
+      }
+
+      // Use 'exit' instead of 'close' when there are no piped stdio streams for us to drain;
+      // 'close' can be deferred past 'exit' when the child has grandchildren that inherit its
+      // stdio fds, so waiting on it without anything to read just stalls
+      const completionEvent =
+        ignoreStdio || (!child.stdout && !child.stderr) ? 'exit' : 'close';
+
+      let completionListener = (code: number | null, signal: string | null) => {
+        child.removeListener('error', errorListener);
+        const argumentString = args && args.length > 0 ? ` ${args.join(' ')}` : '';
+        let error: (Error & { code?: string }) | null = null;
+        if (code !== 0) {
+          error = signal
+            ? new Error(`${command}${argumentString} exited with signal: ${signal}`)
+            : new Error(`${command}${argumentString} exited with non-zero code: ${code}`);
+        }
+        const meta = { pid: child.pid, status: code, signal };
+
+        if (error) {
+          if (error.stack && callerStack) error.stack += `\n${callerStack}`;
+          // When the child exited non-zero we surface that error; the partial stdio is
+          // attached to the rejection (potentially truncated by the sliding window).
+          Object.assign(error, meta, stdioFields());
+          reject(error);
+        } else if (stdoutChunks.maxExceeded || stderrChunks.maxExceeded) {
+          // Output exceeded the cap and the sliding window truncated bytes.
+          // Reject rather than silently returning a clipped result. The
+          // default cap is `MAX_STRING_LENGTH` for both encodings. In text
+          // mode that is also the runtime hard limit, so the only remedy is
+          // switching to `encoding: "buffer"`. In buffer mode the default is
+          // just a chosen cap and the caller can raise `maxBuffer` up to
+          // `MAX_LENGTH` to capture more.
+          let message: string;
+          if (explicitMaxBuffer) {
+            message = `${command}${argumentString} exceeded maxBuffer of ${maxBuffer} bytes`;
+          } else if (wantsBytes) {
+            message =
+              `${command}${argumentString} exceeded the default maxBuffer of ${maxBuffer} bytes. ` +
+              `Pass maxBuffer to capture more output (up to buffer.constants.MAX_LENGTH).`;
+          } else {
+            message =
+              `${command}${argumentString} exceeded the maximum string length ` +
+              `(${maxBuffer} bytes, buffer.constants.MAX_STRING_LENGTH). Pass ` +
+              `encoding: "buffer" to capture this output as raw bytes.`;
+          }
+          const error: Error & { code?: string } = new Error(message);
+          error.code = 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+          Object.assign(error, meta, stdioFields());
+          reject(error);
+        } else {
+          resolve({ ...meta, ...stdioFields() });
+        }
       };
-      reject(attachResult(error, assignResult, stdoutChunks, stderrChunks));
-    };
 
-    child.once(completionEvent, completionListener);
-    child.once('error', errorListener);
-  }) as spawnAsync.SpawnPromise<spawnAsync.SpawnResult>;
+      let errorListener = (error: Error) => {
+        child.removeListener(completionEvent, completionListener);
+        Object.assign(error, { pid: child.pid, status: null, signal: null }, stdioFields());
+        reject(error);
+      };
+
+      child.once(completionEvent, completionListener);
+      child.once('error', errorListener);
+    },
+  ) as spawnAsync.SpawnPromise<spawnAsync.SpawnResult<string | Uint8Array>>;
 
   promise.child = child;
   return promise;


### PR DESCRIPTION
Why
===
`spawnAsync` always decodes child output with `toString('utf8')`, which corrupts binary output, e.g. `pandoc` writing a `.docx` to stdout. (Closes #20.)

How
===
Add an `encoding` option to `SpawnOptions`. `encoding: 'buffer'` returns `stdout` / `stderr` / `output` as `Uint8Array`; the default `'utf8'` and other `BufferEncoding` values are unchanged. `SpawnResult<T = string>` is now parameterized on the stdio element type and overloads select between the string and buffer forms; existing `SpawnResult` references resolve to `SpawnResult<string>` with no source changes.

The result is built once when the process exits, freeing the intermediate chunks immediately instead of retaining them behind lazy getters for the result's lifetime. Exceeding the buffer cap rejects in all cases: an explicit `maxBuffer` already rejected, and the default cap previously resolved then threw lazily on property access.

A `maxBuffer` larger than the encoding's runtime hard limit (`MAX_STRING_LENGTH` for text, `MAX_LENGTH` for `'buffer'`) now throws `TypeError` synchronously at the call site. Previously it was silently clamped, which led to confusing rejection messages later.

Behavior changes from 1.8.0
===========================
| scenario | 1.8.0 | this PR |
| --- | --- | --- |
| Process exits 0, output under cap | resolves with full output | same |
| Process exits non-zero (any output size) | rejects; truncated stdio attached to the error | same |
| Explicit `maxBuffer` exceeded | rejects with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`; truncated stdio attached | same |
| Default cap (`MAX_STRING_LENGTH`) exceeded | resolves; reading `result.stdout` / `result.stderr` lazily throws `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` | rejects with the same code; truncated stdio attached |
| `maxBuffer` larger than the encoding's hard limit | silently clamped via `Math.min` | synchronous `TypeError` at the call site |

Test Plan
=========
Unit tests; the existing suite passes unchanged. New tests:
- returns stdout/stderr as Uint8Array under encoding: 'buffer'
- survives a non-UTF-8 byte sequence: bytes preserved, not replaced
- populates output as [stdout, stderr] of Uint8Array in buffer mode
- attaches bytes to the error on non-zero exit, like string stdout
- enforces maxBuffer under encoding: 'buffer'
- decodes stdout with latin1, and with hex
- rejects suggesting the string-length limit when text default cap is exceeded
- rejects suggesting a larger maxBuffer when bytes default cap is exceeded
- throws TypeError synchronously when maxBuffer exceeds the encoding's hard limit; accepts a maxBuffer exactly equal to it
